### PR TITLE
Added custom jasmine matchers, hidden test examples.

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -8,13 +8,14 @@
 <h2>Here are some links to help you start: </h2>
 <ul>
   <li>
-    <h2><a target="_blank" rel="noopener" href="https://angular.io/tutorial">Tour of Heroes</a></h2>
+    <h2><a class="link1" target="_blank" rel="noopener" href="https://angular.io/tutorial">Tour of Heroes</a></h2>
   </li>
   <li>
-    <h2><a target="_blank" rel="noopener" href="https://github.com/angular/angular-cli/wiki">CLI Documentation</a></h2>
+    <h2><a class="link2" *ngIf="false"  target="_blank" rel="noopener" href="https://github.com/angular/angular-cli/wiki">CLI Documentation</a></h2>
   </li>
   <li>
-    <h2><a target="_blank" rel="noopener" href="https://blog.angular.io/">Angular blog</a></h2>
+    <!-- This link is hidden and will not be displayed to the user -->
+    <h2><a class="link3" [hidden]="true" target="_blank" rel="noopener" href="https://blog.angular.io/">Angular blog</a></h2>
   </li>
 </ul>
 

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -1,5 +1,10 @@
 import { TestBed, async } from '@angular/core/testing';
 import { AppComponent } from './app.component';
+import { By } from '@angular/platform-browser';
+
+// My custom matcher functions
+import { toBeDisplayed, notToBeDisplayed } from './custom-matchers';
+
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -7,21 +12,78 @@ describe('AppComponent', () => {
         AppComponent
       ],
     }).compileComponents();
+
+    // I added custom Jasmine matchers for cleaner tests!
+    jasmine.addMatchers({ toBeDisplayed, notToBeDisplayed });
   }));
-  it('should create the app', async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app).toBeTruthy();
-  }));
-  it(`should have as title 'app'`, async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.debugElement.componentInstance;
-    expect(app.title).toEqual('app');
-  }));
-  it('should render title in a h1 tag', async(() => {
-    const fixture = TestBed.createComponent(AppComponent);
-    fixture.detectChanges();
-    const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('h1').textContent).toContain('Welcome to app!');
-  }));
+
+  describe('using element truthy/falsy', async() => {
+    it('should show link 1', async(() => {
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+      const control = fixture.debugElement.query(By.css('.link1'));
+      expect(control).toBeTruthy();
+    }));
+  
+    it('should not show link 2', async(() => {
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+      const control = fixture.debugElement.query(By.css('.link2'));
+      expect(control).toBeFalsy();
+    }));
+  
+    it('should not show link 3 (should fail but passed)', async(() => {
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+      const control = fixture.debugElement.query(By.css('.link3'));
+
+      // Deliberately fail the test
+      expect(control).toBeTruthy();  // <--- This should fail and it didn't
+      
+      //expect(control).toBeFalsy();
+    }));
+
+    it('should not show link 3 (should fail and did)', async(() => {
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+      const control = fixture.debugElement.query(By.css('.link3:not([hidden]')); // We can add  the :not([hidden])
+                                                                                 // selector to filter out hidden
+                                                                                 // elements. This is messy so check
+                                                                                 // out the custom Jasmine matchers
+                                                                                 // I wrote below.
+
+
+      // Deliberately fail the test
+      expect(control).toBeTruthy();  // <--- This should fail and it did
+      
+      //expect(control).toBeFalsy();
+    }));
+  });
+
+  describe('using custom jasmine matcher', async() => {
+    it('should show link 1', async(() => {
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+      const control = fixture.debugElement.query(By.css('.link1'));
+      expect(control).toBeDisplayed();
+    }));
+  
+    it('should show link 2', async(() => {
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+      const control = fixture.debugElement.query(By.css('.link2'));
+      expect(control).notToBeDisplayed();
+    }));
+  
+    it('should not show link 3 (should fail and did)', async(() => {
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+      const control = fixture.debugElement.query(By.css('.link3'));
+      
+      // Deliberately fail the test      
+      expect(control).toBeDisplayed();  // <--- This should fail and it did!
+
+      // expect(control).notToBeDisplayed();
+    }));
+  });
 });

--- a/src/app/custom-matchers.ts
+++ b/src/app/custom-matchers.ts
@@ -1,0 +1,34 @@
+import { DebugElement } from "@angular/core";
+// Custom matchers that checks the existence of th element
+// and if they contain the hidden attribute.
+function toBeDisplayed() {
+    return {
+        compare: function(el: DebugElement) {
+            const result = {
+                pass: !!el && !el.nativeElement.hasAttribute('hidden')
+            }
+            if (!result.pass) {
+                result['message'] = "Expected element to be displayed";
+            }
+            return result;
+        }
+    };
+}
+
+// Custom matchers that checks the existence of th element
+// and if they contain the hidden attribute.
+function notToBeDisplayed() {
+    return {
+        compare: function(el: DebugElement) {
+            const result = {
+                pass: !el || el.nativeElement.hasAttribute('hidden')
+            }
+            if (!result.pass) {
+                result['message'] = "Expected element not to be displayed";
+            }
+            return result;
+        }
+    };
+}
+
+export { toBeDisplayed, notToBeDisplayed }

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -3,3 +3,12 @@ declare var module: NodeModule;
 interface NodeModule {
   id: string;
 }
+
+// To get the TypeScript to compile my custom ambient type
+// type I declare them in the typings.d.ts file.
+declare namespace jasmine {
+  interface Matchers<T> {
+    toBeDisplayed(expectationFailOutput?: any): boolean;
+    notToBeDisplayed(expectationFailOutput?: any): boolean;
+  }
+}


### PR DESCRIPTION
# Examples of the dangers of [hidden] and truthy tests

Things I showed in this PR:
1. I deliberately failed a truthy test with [hidden] but it passed
2. I showed how to use the css filter `:not([hidden])` to make your truthy account for `[hidden]` elements
3. A cleaner way to check for displayed and hidden elements using a custom Jasmine matcher